### PR TITLE
Corrected label description for the on hold label

### DIFF
--- a/labelsync.yml
+++ b/labelsync.yml
@@ -85,7 +85,7 @@ labels: &common
     description: This pull request has been reviewed by QA and approved
   "on hold":
     color: *status
-    description: This issue or pull request is currently waiting on another issue or pull request to be resolved before work can continue
+    description: This issue or PR is waiting on another issue or PR to be resolved before work can continue
   "all roles":
     color: *user-role
     description: This issue or pull request affects all user roles


### PR DESCRIPTION
Per the Label-Sync dev: The problem is that the "on hold" label has too long a description. Because of that label-sync stops updating once it hits the error