### PR TITLE
Added Email Followup Required label

### DIFF
--- a/labelsync.yml
+++ b/labelsync.yml
@@ -78,9 +78,6 @@ labels: &common
     color: *info
     description: Technical debt incurred during previous development changes
   # process #########################
-  "company email needed":
-    color: *process
-    description: A company-wide email will need to be sent before this pull request goes into production
   "email followup required":
     color: *process
     description: This issue or PR requires follow up with affected users before merging

--- a/labelsync.yml
+++ b/labelsync.yml
@@ -71,7 +71,7 @@ labels: &common
   "company email needed":
     color: *process
     description: A company-wide email will need to be sent before this pull request goes into production
-   "email followup required":
+  "email followup required":
     color: *process
     description: This issue or PR requires follow up with affected users before merging
   "happyfox followup required":

--- a/labelsync.yml
+++ b/labelsync.yml
@@ -71,6 +71,9 @@ labels: &common
   "company email needed":
     color: *process
     description: A company-wide email will need to be sent before this pull request goes into production
+   "email followup required":
+    color: *process
+    description: This issue or PR requires follow up with affected users before merging
   "happyfox followup required":
     color: *process
     description: This issue or PR is related to an active happyfox ticket that requires follow up


### PR DESCRIPTION
### In This PR
- Added the "email followup required" label at the request of QA to help mark issues and PR's that require an email followup with a specific user before going live.